### PR TITLE
add survival output generation

### DIFF
--- a/run-v1.sh
+++ b/run-v1.sh
@@ -13,7 +13,7 @@
 
 set -eu
 
-TILALIGN_VERSION="458bb04"
+TILALIGN_VERSION="df598d1"
 
 usage() {
     cat << EOF


### PR DESCRIPTION
this pr adds the survival component of the analysis pipeline. @lthealy - i had to add many things to get this working properly so i opened this pr. this replaces #6.

i get this error when using the sample survival CSV in the til align repo (happens when rendering the r markdown). do you have a dataset we can use to test the full pipeline with? i'm assuming this happens because there are not enough samples?

we should probably account for this potential error.. depending on why it happens. for instance what if users run into this. what should we tell them to do?

```r
processing file: Descriptive_Statistics.rmd
  |...                                                                   |   5%
   inline R code fragments

  |......                                                                |   9%
label: setup (with options) 
List of 1
 $ include: logi FALSE

  |..........                                                            |  14%
  ordinary text without R code

  |.............                                                         |  18%
label: load (with options) 
List of 1
 $ include: logi FALSE

  |................                                                      |  23%
  ordinary text without R code

  |...................                                                   |  27%
label: unnamed-chunk-1 (with options) 
List of 1
 $ fig.height: num 4

  |......................                                                |  32%
   inline R code fragments

  |.........................                                             |  36%
label: unnamed-chunk-2
Quitting from lines 67-83 (Descriptive_Statistics.rmd) 
Error in chisq.test(chi) : at least one entry of 'x' must be positive
Calls: <Anonymous> ... eval_with_user_handlers -> eval -> eval -> chisq.test
In addition: Warning messages:
1: Removed 4 rows containing non-finite values (stat_bin). 
2: In chisq.test(chi) : Chi-squared approximation may be incorrect
3: In chisq.test(chi) : Chi-squared approximation may be incorrect
```

related to #3 